### PR TITLE
Fix collapsed event total_size and prop_covered calculation for overlapping events in collapseEvents.R

### DIFF
--- a/R/collapseEvents.R
+++ b/R/collapseEvents.R
@@ -110,9 +110,12 @@ collapseEvents <- function(subset_df, min_ME = 2, min_size = 500e3) {
     region_max <- max(df$end,   na.rm = TRUE)
     region_span <- region_max - region_min
     
-    event_sizes <- df$event_size
-    snps        <- df$n_snps
+    ranges <- IRanges::IRanges(start = df$start, end = df$end - 1)
+    merged_ranges <- IRanges::reduce(ranges)
+    covered_size <- sum(IRanges::width(merged_ranges))
     
+    snps        <- df$n_snps
+ 
     w <- snps
     
     ratio_father_val  <- if(all(is.na(df$ratio_father)))  NA_real_ else stats::weighted.mean(df$ratio_father,  w, na.rm = TRUE)
@@ -127,9 +130,9 @@ collapseEvents <- function(subset_df, min_ME = 2, min_size = 500e3) {
       group = df$group[1],
       n_events = nrow(df),
       total_mendelian_error = sum(df$n_mendelian_error, na.rm = TRUE),
-      total_size = sum(event_sizes, na.rm = TRUE),
+      total_size = region_span,
       total_snps = sum(snps, na.rm = TRUE),
-      prop_covered = sum(event_sizes, na.rm = TRUE) / region_span,
+      prop_covered = covered_size / region_span,
       ratio_father  = ratio_father_val,
       ratio_mother  = ratio_mother_val,
       ratio_proband = ratio_proband_val,

--- a/R/markRecurrentRegions.R
+++ b/R/markRecurrentRegions.R
@@ -1,23 +1,31 @@
 #' Annotate regions as recurrent or non-recurrent
 #'
 #' Given a results data.frame and a set of recurrent genomic regions,
-#' this function labels each row as "Yes" (recurrent) or "No".
+#' this function labels each row as "Yes" (recurrent) or "No" (non-recurrent)
+#' based on overlaps with a set of recurrent regions.
 #'
 #' @param df Data.frame with region coordinates and sample IDs.
 #' @param recurrent_regions GRanges object from identifyRecurrentRegions().
-#'
+#' @param min_overlap Numeric between 0 and 1, default = 0.7.
+#'    Minimum fraction of the input region that must overlap a recurrent region to be annotated as recurrent.
+#'   
+#' @details
+#' A region is marked as recurrent if the fraction of its length overlapping a recurrent region 
+#' is at least `min_overlap` (default 0.7).
+#' 
 #' @return The same data.frame with two added columns:
 #'   - Recurrent: "Yes" or "No"
 #'   - n_samples: Number of supporting samples (if recurrent)
+#'   
 #' @export
 #' @examples
 #' input <- data.frame(
-#'ID = c("S1", "S2", "S3", "S4"),
-#'chromosome = c("chr1", "chr1", "chr1", "chr2"),
-#'start = c(100, 120, 500, 100),
-#'end = c(150, 170, 550, 150),
-#'n_mendelian_error = c(10, 20, 5, 200)
-#')
+#'     ID = c("S1", "S2", "S3", "S4"),
+#'     chromosome = c("chr1", "chr1", "chr1", "chr2"),
+#'     start = c(100, 150, 500, 100),
+#'     end = c(150, 200, 550, 150),
+#'     n_mendelian_error = c(10, 20, 5, 200)
+#' )
 #'
 #'recurrent_gr <- GenomicRanges::GRanges(
 #'  seqnames = "chr1",
@@ -28,19 +36,13 @@
 #'  n_samples = 2
 #')
 #' markRecurrentRegions(input, recurrent_gr)
-markRecurrentRegions <- function(df, recurrent_regions) {
+#' 
+markRecurrentRegions <- function(df, recurrent_regions, min_overlap = 0.7) {
   
   # --- Detect coordinate columns automatically ---
-  if (all(c("start", "end") %in% colnames(df))) {
-    start_col <- "start"
-    end_col   <- "end"
-  } else if (all(c("min_start", "max_end") %in% colnames(df))) {
-    start_col <- "min_start"
-    end_col   <- "max_end"
-  } else {
-    stop("Input must contain either (start, end) or (min_start, max_end) columns.")
+  if (!all(c("start", "end") %in% names(df))) {
+    stop("Input must contain columns 'start' and 'end'.")
   }
-  
   
   # --- Initialize default output columns ---
   df$Recurrent <- "No"
@@ -54,21 +56,39 @@ markRecurrentRegions <- function(df, recurrent_regions) {
   # --- Convert input table to GRanges ---
   gr <- GenomicRanges::GRanges(
     seqnames = df$chromosome,
-    ranges = IRanges::IRanges(
-      start = as.numeric(df[[start_col]]),
-      end = as.numeric(df[[end_col]])
-    ),
-    ID = df$ID
+    ranges   = IRanges::IRanges(df$start, df$end),
+    ID       = df$ID
   )
   
-  
+  # --- Identify overlaps with recurrent regions ---
   overlaps <- GenomicRanges::findOverlaps(gr, recurrent_regions)
   
-  if (length(overlaps) > 0) {
-    df$Recurrent[S4Vectors::queryHits(overlaps)] <- "Yes"
-    df$n_samples[S4Vectors::queryHits(overlaps)] <-
-      recurrent_regions$n_samples[S4Vectors::subjectHits(overlaps)]
+  # --- If no overlaps are found, return input unchanged ---
+  if (length(overlaps) == 0) {
+    return(df)
   }
+  
+  qh <- S4Vectors::queryHits(overlaps)
+  sh <- S4Vectors::subjectHits(overlaps)
+  
+  # --- Compute overlap fraction for each overlapping event ---
+  
+  # Compute intersection between input regions and recurrent regions
+  ov <- GenomicRanges::pintersect(gr[qh], recurrent_regions[sh])
+  
+  # Fraction of the input event covered by the recurrent region
+  frac_covered <- IRanges::width(ov) / IRanges::width(gr[qh])
+  
+  # Retain only events exceeding the minimum overlap threshold
+  keep <- frac_covered >= min_overlap
+  
+  # --- Annotate recurrent events ---
+  if (any(keep)) {
+    df$Recurrent[qh[keep]] <- "Yes"
+    df$n_samples[qh[keep]] <-
+      recurrent_regions$n_samples[sh[keep]]
+  }
+  
   rownames(df) <- NULL
   return(df)
 }

--- a/man/markRecurrentRegions.Rd
+++ b/man/markRecurrentRegions.Rd
@@ -4,12 +4,15 @@
 \alias{markRecurrentRegions}
 \title{Annotate regions as recurrent or non-recurrent}
 \usage{
-markRecurrentRegions(df, recurrent_regions)
+markRecurrentRegions(df, recurrent_regions, min_overlap = 0.7)
 }
 \arguments{
 \item{df}{Data.frame with region coordinates and sample IDs.}
 
 \item{recurrent_regions}{GRanges object from identifyRecurrentRegions().}
+
+\item{min_overlap}{Numeric between 0 and 1, default = 0.7.
+Minimum fraction of the input region that must overlap a recurrent region to be annotated as recurrent.}
 }
 \value{
 The same data.frame with two added columns:
@@ -20,15 +23,20 @@ The same data.frame with two added columns:
 }
 \description{
 Given a results data.frame and a set of recurrent genomic regions,
-this function labels each row as "Yes" (recurrent) or "No".
+this function labels each row as "Yes" (recurrent) or "No" (non-recurrent)
+based on overlaps with a set of recurrent regions.
+}
+\details{
+A region is marked as recurrent if the fraction of its length overlapping a recurrent region
+is at least \code{min_overlap} (default 0.7).
 }
 \examples{
 input <- data.frame(
-ID = c("S1", "S2", "S3", "S4"),
-chromosome = c("chr1", "chr1", "chr1", "chr2"),
-start = c(100, 120, 500, 100),
-end = c(150, 170, 550, 150),
-n_mendelian_error = c(10, 20, 5, 200)
+    ID = c("S1", "S2", "S3", "S4"),
+    chromosome = c("chr1", "chr1", "chr1", "chr2"),
+    start = c(100, 150, 500, 100),
+    end = c(150, 200, 550, 150),
+    n_mendelian_error = c(10, 20, 5, 200)
 )
 
 recurrent_gr <- GenomicRanges::GRanges(
@@ -40,4 +48,5 @@ recurrent_gr <- GenomicRanges::GRanges(
  n_samples = 2
 )
 markRecurrentRegions(input, recurrent_gr)
+
 }

--- a/tests/testthat/test-collapseEvents.R
+++ b/tests/testthat/test-collapseEvents.R
@@ -1,15 +1,15 @@
 # Input test dataframe
 test_df <- data.frame(
-    ID = c("S1", "S1", "S1", "S1", "S1", "S2", "S2"),
-    chromosome = c("1", "1", "1", "1", "1", "2", "2"),
-    start = c(50, 75, 100, 150, 300, 500, 550),
-    end = c(70, 85, 120, 180, 320, 520, 580),
-    n_snps = c(5, 3, 8, 10, 6, 12, 7),
-    group = c("iso_mat", "iso_mat", "iso_mat", "iso_mat", "het_pat", "iso_mat", "iso_mat"),
-    n_mendelian_error = c(1, 5, 5, 10, 3, 50, 30),
-    ratio_father  = rep(NA_real_, 7),
-    ratio_mother  = rep(NA_real_, 7),
-    ratio_proband = rep(NA_real_, 7),
+    ID = c("S1", "S1", "S1", "S1", "S1", "S1", "S2", "S2"),
+    chromosome = c("1", "1", "1", "1", "1","1","2", "2"),
+    start = c(50, 75, 100, 110, 150, 300, 500, 550),
+    end = c(70, 85, 120, 130, 180, 320, 520, 580),
+    n_snps = c(5, 3, 8, 10, 10, 6, 12, 7),
+    group = c("iso_mat", "iso_mat", "iso_mat", "iso_mat", "iso_mat", "het_pat", "iso_mat", "iso_mat"),
+    n_mendelian_error = c(1, 5, 5, 10, 10,  3, 50, 30),
+    ratio_father  = rep(NA_real_, 8),
+    ratio_mother  = rep(NA_real_, 8),
+    ratio_proband = rep(NA_real_, 8),
     stringsAsFactors = FALSE
   )
 
@@ -21,15 +21,15 @@ expected_result <- data.frame(
     start = c(300,100, 500),
     end = c(320, 180, 580),
     group = c("het_pat","iso_mat", "iso_mat"),
-    n_events = c(1, 2, 2),
-    total_mendelian_error = c(3, 15, 80),
-    total_size = c(20, 50, 50),
-    total_snps = c(6, 18, 19),
-    prop_covered = c(1, 0.625, 0.625),
+    n_events = c(1, 3, 2),
+    total_mendelian_error = c(3, 25, 80),
+    total_size = c(20, 80, 80),
+    total_snps = c(6, 28, 19),
+    prop_covered = c(1, 0.75, 0.625),
     ratio_father  = rep(NA_real_, 3),
     ratio_mother  = rep(NA_real_, 3),
     ratio_proband = rep(NA_real_, 3),
-    collapsed_events = c( "1:300-320","1:100-120,1:150-180", "2:500-520,2:550-580"),
+    collapsed_events = c( "1:300-320","1:100-120,1:110-130,1:150-180", "2:500-520,2:550-580"),
     stringsAsFactors = FALSE
   )
   
@@ -86,7 +86,7 @@ expected_result <- data.frame(
   group = c("het_pat","iso_mat", "iso_mat"),
   n_events = c(1, 2, 2),
   total_mendelian_error = c(3, 15, 80),
-  total_size = c(20, 50, 50),
+  total_size = c(20, 80, 80),
   total_snps = c(6, 18, 19),
   prop_covered = c(1, 0.625, 0.625),
   ratio_father  = c(0.99, 0.97, 1.00),

--- a/tests/testthat/test-markRecurrentRegions.R
+++ b/tests/testthat/test-markRecurrentRegions.R
@@ -1,28 +1,26 @@
 input <- data.frame(
   ID = c("S1", "S2", "S3", "S4"),
-  chromosome = c("chr1", "chr1", "chr1", "chr2"),
-  start = c(100, 120, 500, 100),
-  end = c(150, 170, 550, 150),
-  n_mendelian_error = c(10, 20, 5, 200)
+  chromosome = c("chr1", "chr1", "chr1", "chr1"),
+  start = c(100, 150, 182, 400),
+  end   = c(300, 350, 382, 500)
 )
 
 recurrent_gr <- GenomicRanges::GRanges(
   seqnames = "chr1",
   ranges = IRanges::IRanges(
-    start = 100,
-    end = 170
+    start = 120, 
+    end = 320
   ),
-  n_samples = 2
+  n_samples = 3
 )
 
 expected <- data.frame(
   ID = c("S1", "S2", "S3", "S4"),
-  chromosome = c("chr1", "chr1", "chr1", "chr2"),
-  start = c(100, 120, 500, 100),
-  end = c(150, 170, 550, 150),
-  n_mendelian_error = c(10, 20, 5, 200),
+  chromosome = c("chr1", "chr1", "chr1", "chr1"),
+  start = c(100, 150, 182, 400),
+  end   = c(300, 350, 382, 500),
   Recurrent = c("Yes", "Yes", "No", "No"),
-  n_samples = c(2,2,1,1)
+  n_samples = c(3, 3, 1, 1)
 )
 
 test_that("Test if markRecurrentRegions works", {


### PR DESCRIPTION
- Replaced total_size computation from sum of individual event sizes to the actual genomic span (region_max - region_min).
- Calculated the proportion of the region covered (prop_covered) using merged IRanges to avoid double-counting overlapping events.
- Updated tests to ensure this adaptation works correctly.