### PR TITLE
Improve recurrent region detection and event annotation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: UPDhmm
 Title: Detecting Uniparental Disomy through NGS trio data
-Version: 1.5.3
+Version: 1.7.1
 BugReports: https://github.com/martasevilla/UPDhmm/issues
 Authors@R: 
   c(person(given = "Marta",

--- a/R/collapseEvents.R
+++ b/R/collapseEvents.R
@@ -110,9 +110,12 @@ collapseEvents <- function(subset_df, min_ME = 2, min_size = 500e3) {
     region_max <- max(df$end,   na.rm = TRUE)
     region_span <- region_max - region_min
     
-    event_sizes <- df$event_size
-    snps        <- df$n_snps
+    ranges <- IRanges::IRanges(start = df$start, end = df$end - 1)
+    merged_ranges <- IRanges::reduce(ranges)
+    covered_size <- sum(IRanges::width(merged_ranges))
     
+    snps        <- df$n_snps
+ 
     w <- snps
     
     ratio_father_val  <- if(all(is.na(df$ratio_father)))  NA_real_ else stats::weighted.mean(df$ratio_father,  w, na.rm = TRUE)
@@ -127,9 +130,9 @@ collapseEvents <- function(subset_df, min_ME = 2, min_size = 500e3) {
       group = df$group[1],
       n_events = nrow(df),
       total_mendelian_error = sum(df$n_mendelian_error, na.rm = TRUE),
-      total_size = sum(event_sizes, na.rm = TRUE),
+      total_size = region_span,
       total_snps = sum(snps, na.rm = TRUE),
-      prop_covered = sum(event_sizes, na.rm = TRUE) / region_span,
+      prop_covered = covered_size / region_span,
       ratio_father  = ratio_father_val,
       ratio_mother  = ratio_mother_val,
       ratio_proband = ratio_proband_val,

--- a/R/collapseEvents.R
+++ b/R/collapseEvents.R
@@ -5,8 +5,8 @@
 #' and a string listing all merged event coordinates.
 #'
 #' @details
-#' When values are available in the ratio columns (`ratio_proband`, `ratio_mother`, `ratio_father`) 
-#' are present, weighted mean ratios are computed across the collapsed events.
+#' When values are available in the ratio columns (`ratio_proband`, `ratio_mother`, `ratio_father`), 
+#' weighted mean ratios are computed across the collapsed events.
 #' The weighted mean ratio is calculated as:
 #'
 #' \deqn{\frac{\sum_{i} r_i \times N_i}{\sum_{i} N_i}}

--- a/R/collapseEvents.R
+++ b/R/collapseEvents.R
@@ -5,8 +5,8 @@
 #' and a string listing all merged event coordinates.
 #'
 #' @details
-#' When ratio columns (`ratio_proband`, `ratio_mother`, `ratio_father`) are present,
-#' weighted mean ratios are computed across the collapsed events.
+#' When values are available in the ratio columns (`ratio_proband`, `ratio_mother`, `ratio_father`) 
+#' are present, weighted mean ratios are computed across the collapsed events.
 #' The weighted mean ratio is calculated as:
 #'
 #' \deqn{\frac{\sum_{i} r_i \times N_i}{\sum_{i} N_i}}
@@ -110,10 +110,7 @@ collapseEvents <- function(subset_df, min_ME = 2, min_size = 500e3) {
     region_max <- max(df$end,   na.rm = TRUE)
     region_span <- region_max - region_min
     
-    ranges <- IRanges::IRanges(start = df$start, end = df$end - 1)
-    merged_ranges <- IRanges::reduce(ranges)
-    covered_size <- sum(IRanges::width(merged_ranges))
-    
+    event_sizes <- df$event_size
     snps        <- df$n_snps
  
     w <- snps
@@ -132,7 +129,7 @@ collapseEvents <- function(subset_df, min_ME = 2, min_size = 500e3) {
       total_mendelian_error = sum(df$n_mendelian_error, na.rm = TRUE),
       total_size = region_span,
       total_snps = sum(snps, na.rm = TRUE),
-      prop_covered = covered_size / region_span,
+      prop_covered = sum(event_sizes, na.rm = TRUE) / region_span,
       ratio_father  = ratio_father_val,
       ratio_mother  = ratio_mother_val,
       ratio_proband = ratio_proband_val,

--- a/R/identifyRecurrentRegions.R
+++ b/R/identifyRecurrentRegions.R
@@ -1,12 +1,9 @@
 #' Identify recurrent genomic regions across samples
 #'
 #' This function identifies recurrent genomic regions supported by multiple
-#' samples based on overlapping genomic intervals. Intervals are first filtered
-#' by a Mendelian error threshold. Events are then clustered using an
-#' agglomerative hierarchical approach within each chromosome, with the distance
-#' between events defined based on their overlap. Clusters supported by a minimum
-#' number of distinct samples are retained and collapsed into recurrent regions
-#' summarizing all contributing events.
+#' samples based on overlapping genomic intervals. UPD events are clustered based
+#' on their reciprocal overlap. Recurrent regions are defined as clusters supported
+#' by a minimum number of samples.
 #' 
 #' @param df A data.frame with columns:
 #'   - ID: Sample identifier.
@@ -44,13 +41,13 @@
 #' 
 #' @details
 #' The function operates chromosome-wise and proceeds in several steps. First,
-#' events are filtered based on a maximum Mendelian error threshold. Then, a
+#' events with a high number of Mendelian errors are filtered out. Then, a
 #' pairwise distance matrix is computed for overlapping events, where the
 #' distance between two events e1 and e2 is defined as:
 #'
 #' \deqn{1 - (overlap\_width / max(width(e1), width(e2)))}
 #'
-#' Event pairs that do not overlap are not explicitly evaluated and are directly
+#' Event pairs that do not overlap are not explicitly evaluated and are 
 #' assigned a distance of 1. In addition, only the upper triangular part of the
 #' distance matrix is computed, exploiting its symmetry to avoid redundant
 #' calculations and reduce computational cost.

--- a/R/identifyRecurrentRegions.R
+++ b/R/identifyRecurrentRegions.R
@@ -33,8 +33,7 @@
 #'   \itemize{
 #'     \item \code{n_samples} – number of distinct samples supporting the region.
 #'     \item \code{supporting_events} – a GRangesList with the individual events
-#'       that compose the recurrent region, including per-event coverage metrics
-#'       (pct_event_covered, pct_region_covered).
+#'       that compose the recurrent region.
 #'   }
 #'   
 #' The \code{supporting_events} correspond exactly to the original events that
@@ -164,15 +163,14 @@ identifyRecurrentRegionsByChr  <- function(df,
   #---------------------------------------------------------------
   # 2. Convert to GRanges
   #---------------------------------------------------------------
-  gr <- GenomicRanges::GRanges(
-    seqnames = df$chromosome,
-    ranges = IRanges::IRanges(
-      start = as.numeric(df[["start"]]),
-      end   = as.numeric(df[["end"]])
-    ),
-    ID = df[[ID_col]],
-    n_mendelian_error = df[[err_col]]
+  gr <- GenomicRanges::makeGRangesFromDataFrame(
+    df,
+    seqnames.field = "chromosome",
+    start.field    = "start",
+    end.field      = "end",
+    keep.extra.columns = TRUE
   )
+  
   
   #---------------------------------------------------------------
   # 3. Filter by error threshold
@@ -248,11 +246,6 @@ identifyRecurrentRegionsByChr  <- function(df,
     # Define region boundaries spanning all supporting events
     region_start <- min(GenomicRanges::start(events))
     region_end   <- max(GenomicRanges::end(events))
-    
-    region_gr_tmp <- GenomicRanges::GRanges(
-      seqnames = GenomicRanges::seqnames(events),
-      ranges   = IRanges::IRanges(region_start, region_end)
-    )
     
     GenomicRanges::GRanges(
       seqnames = GenomicRanges::seqnames(events)[1],

--- a/R/identifyRecurrentRegions.R
+++ b/R/identifyRecurrentRegions.R
@@ -1,38 +1,147 @@
 #' Identify recurrent genomic regions across samples
 #'
-#' This function finds recurrent genomic regions across samples based on overlapping intervals.
-#' Regions exceeding the Mendelian error threshold are excluded.
-#'
+#' This function identifies recurrent genomic regions supported by multiple
+#' samples based on overlapping genomic intervals. Intervals are first filtered
+#' by a Mendelian error threshold. Events are then clustered using an
+#' agglomerative hierarchical approach within each chromosome, with the distance
+#' between events defined based on their overlap. Clusters supported by a minimum
+#' number of distinct samples are retained and collapsed into recurrent regions
+#' summarizing all contributing events.
+#' 
 #' @param df A data.frame with columns:
 #'   - ID: Sample identifier.
 #'   - chromosome: Chromosome name.
 #'   - start: Start coordinate of the region.
 #'   - end: End coordinate of the region.
-#'   - n_mendelian_error: Number of Mendelian errors in the region.
+#'   - n_mendelian_error or total_mendelian_error: Number of Mendelian errors in the region.
 #' @param error_threshold Numeric, default = 100.
 #'   Maximum number of Mendelian errors allowed for a region to be considered.
 #' @param min_support Integer, default = 3.
 #'   Minimum number of unique samples required to call a region recurrent.
 #' @param ID_col Character string indicating the column name containing
 #'   sample identifiers. Default is `"ID"`.
+#' @param max_dist Numeric, default = 0.3.
+#'   Maximum distance allowed to group events in the same cluster when cutting
+#'   the hierarchical clustering dendrogram.
+#' @param linkage Character string specifying the linkage method for the
+#'   agglomerative hierarchical clustering. Default `"complete"`, where the
+#'   distance between two clusters is defined as the largest distance between
+#'   all possible pairs of events belonging to the two clusters.
 #'
 #' @return A GRanges object containing the recurrent regions that meet
-#'   the minimum support threshold.
+#'   the minimum support threshold. Metadata columns include:
+#'   \itemize{
+#'     \item \code{n_samples} – number of distinct samples supporting the region.
+#'     \item \code{supporting_events} – a GRangesList with the individual events
+#'       that compose the recurrent region, including per-event coverage metrics
+#'       (pct_event_covered, pct_region_covered).
+#'   }
+#'   
+#' The \code{supporting_events} correspond exactly to the original events that
+#'   were grouped into the cluster and define the boundaries of the resulting
+#'   recurrent region.
+#'   
+#' If no clusters meet the filtering criteria, the function returns \code{NULL}.
+#' 
+#' @details
+#' The function operates chromosome-wise and proceeds in several steps. First,
+#' events are filtered based on a maximum Mendelian error threshold. Then, a
+#' pairwise distance matrix is computed for overlapping events, where the
+#' distance between two events e1 and e2 is defined as:
+#'
+#' \deqn{1 - (overlap\_width / max(width(e1), width(e2)))}
+#'
+#' Event pairs that do not overlap are not explicitly evaluated and are directly
+#' assigned a distance of 1. In addition, only the upper triangular part of the
+#' distance matrix is computed, exploiting its symmetry to avoid redundant
+#' calculations and reduce computational cost.
+#'
+#' Agglomerative hierarchical clustering is applied to this distance matrix. At
+#' each step, the most similar clusters are merged according to the specified
+#' linkage method (\code{linkage}), with the default \code{"complete"} linkage
+#' using the maximum distance between all possible pairs of events from the two
+#' clusters. The resulting dendrogram is cut at a height defined by
+#' \code{max_dist}, which represents the maximum distance allowed for events to
+#' be grouped in the same cluster. Smaller values enforce stricter overlap
+#' similarity.
+#'
+#' Only clusters supported by at least \code{min_support} distinct samples are
+#' retained. Each valid cluster is then collapsed into a single recurrent region
+#' whose coordinates span all contributing events, and the original events are
+#' stored as \code{supporting_events} with coverage metrics.
+#' 
+#' These steps are performed internally by a helper function \code{identifyRecurrentRegionsByChr}.
+#' Results from all chromosomes are then combined into a single GRanges object returned by this function.
+#' 
 #' @export
 #' @examples
 #' df <- data.frame(
-#' ID = c("S1", "S2", "S3", "S3"),
-#' chromosome = c("chr1", "chr1", "chr1", "chr1"),
-#' start = c(100, 120, 500, 510),
-#' end = c(150, 170, 550, 560),
-#' n_mendelian_error = c(10, 20, 5, 5)
+#'   ID = c("S1", "S2", "S3", "S4"),
+#'   chromosome = c("chr1", "chr1", "chr1", "chr1"),
+#'   start = c(100, 120, 500, 510),
+#'   end = c(150, 170, 550, 560),
+#'   n_mendelian_error = c(10, 20, 5, 5)
 #' )
 #' identifyRecurrentRegions(df, ID_col = "ID", error_threshold = 50, min_support = 2)
-
+#' 
 identifyRecurrentRegions <- function(df,
                                      ID_col = "ID",
                                      error_threshold = 100,
-                                     min_support = 3) {
+                                     min_support = 3,
+                                     max_dist = 0.3,
+                                     linkage = "complete") {
+  
+  #---------------------------------------------------------------
+  # 1. Validate inputs
+  #---------------------------------------------------------------
+  if (!"chromosome" %in% names(df)) {
+    stop("Input must contain column 'chromosome'.")
+  }
+  
+  #---------------------------------------------------------------
+  # 2. Split data by chromosome
+  #---------------------------------------------------------------
+  data_by_chr <- split(df, df$chromosome)
+  
+  #---------------------------------------------------------------
+  # 3. Apply recurrent region detection per chromosome
+  #---------------------------------------------------------------
+  recurrent_by_chr <- lapply(data_by_chr, function(x) {
+    identifyRecurrentRegionsByChr(
+      df = x,
+      ID_col = ID_col,
+      error_threshold = error_threshold,
+      min_support = min_support,
+      max_dist = max_dist,
+      linkage = linkage
+    )
+  })
+  
+  #---------------------------------------------------------------
+  # 4. Remove chromosomes without recurrent regions
+  #---------------------------------------------------------------
+  recurrent_by_chr <- recurrent_by_chr[!sapply(recurrent_by_chr, is.null)]
+  
+  if (length(recurrent_by_chr) == 0) {
+    return(NULL)
+  }
+  
+  #---------------------------------------------------------------
+  # 5. Combine results into a single GRanges object
+  #---------------------------------------------------------------
+  grl <- GenomicRanges::GRangesList(recurrent_by_chr)
+  
+  return (unlist(grl, use.names = FALSE))
+}
+
+
+identifyRecurrentRegionsByChr  <- function(df,
+                                           ID_col = "ID",
+                                           error_threshold = 100,
+                                           min_support = 3,
+                                           max_dist = 0.3,
+                                           linkage = "complete") {
+  
   #---------------------------------------------------------------
   # 1. Validate inputs
   #---------------------------------------------------------------
@@ -40,19 +149,17 @@ identifyRecurrentRegions <- function(df,
     stop(sprintf("Column '%s' not found in input dataframe.", ID_col))
   }
   
-  if (all(c("start", "end") %in% colnames(df))) {
-    start_col <- "start"
-    end_col   <- "end"
-  } else if (all(c("min_start", "max_end") %in% colnames(df))) {
-    start_col <- "min_start"
-    end_col   <- "max_end"
-  } else {
-    stop("Input must contain either (start, end) or (min_start, max_end) columns.")
+  if (!all(c("start", "end") %in% names(df))) {
+    stop("Input must contain columns 'start' and 'end'.")
   }
   
-  err_col <- if ("n_mendelian_error" %in% names(df)) "n_mendelian_error" else
-    if ("total_mendelian_error" %in% names(df)) "total_mendelian_error" else
-      stop("Input must contain either n_mendelian_error or total_mendelian_error column.")
+  err_col <- if ("n_mendelian_error" %in% names(df)) {
+    "n_mendelian_error"
+  } else if ("total_mendelian_error" %in% names(df)) {
+    "total_mendelian_error"
+  } else {
+    stop("Input must contain either 'n_mendelian_error' or 'total_mendelian_error'.")
+  }
   
   #---------------------------------------------------------------
   # 2. Convert to GRanges
@@ -60,41 +167,100 @@ identifyRecurrentRegions <- function(df,
   gr <- GenomicRanges::GRanges(
     seqnames = df$chromosome,
     ranges = IRanges::IRanges(
-      start = as.numeric(df[[start_col]]),
-      end = as.numeric(df[[end_col]])
+      start = as.numeric(df[["start"]]),
+      end   = as.numeric(df[["end"]])
     ),
     ID = df[[ID_col]],
     n_mendelian_error = df[[err_col]]
   )
   
   #---------------------------------------------------------------
-  # 3. Filter and merge overlapping regions
+  # 3. Filter by error threshold
   #---------------------------------------------------------------
-  gr_filtered <- gr[S4Vectors::mcols(gr)$n_mendelian_error < error_threshold]
+  keep <- S4Vectors::mcols(gr)$n_mendelian_error < error_threshold
+  if (!any(keep)) return(NULL)
   
-  if (length(gr_filtered) == 0)
-    return(GenomicRanges::GRanges())
+  gr <- gr[keep]
+  n  <- length(gr)
   
-  reduced_gr <- GenomicRanges::reduce(gr_filtered)
-  
-  #---------------------------------------------------------------
-  # 4. Count distinct samples per merged region
-  #---------------------------------------------------------------
-  hits <- GenomicRanges::findOverlaps(reduced_gr, gr_filtered)
-  hits_df <- data.frame(
-    region_index = S4Vectors::queryHits(hits),
-    ID = S4Vectors::mcols(gr_filtered)$ID[S4Vectors::subjectHits(hits)],
-    stringsAsFactors = FALSE
-  )
-  
-  region_support <- stats::aggregate(ID ~ region_index, data = hits_df,
-                                     FUN = function(x) length(unique(x)))
+  # Check if there are enough events to cluster
+  if (n < 2) {
+    return(NULL)
+  }
   
   #---------------------------------------------------------------
-  # 5. Keep only recurrent regions
+  # 4. Distance matrix
   #---------------------------------------------------------------
-  recurrent_regions <- reduced_gr[region_support$ID >= min_support]
-  recurrent_regions$n_samples <- region_support$ID[region_support$ID >= min_support]
   
-  return(recurrent_regions)
+  # Initialize distance matrix with maximum distance (1 = no overlap)
+  dist_mat <- matrix(1, n, n)
+  
+  # Identify overlapping event pairs (distance is computed only for these to reduce computational cost)
+  hits <- GenomicRanges::findOverlaps(gr, gr)
+  qh <- S4Vectors::queryHits(hits)
+  sh <- S4Vectors::subjectHits(hits)
+  
+  # Retain only the upper triangular matrix to avoid redundant computations
+  upper <- qh < sh 
+  qh <- qh[upper]
+  sh <- sh[upper]
+  
+  # Compute distance as 1 - (overlap / maximum event width)
+  ov <- GenomicRanges::pintersect(gr[qh], gr[sh])
+  max_len <- pmax(IRanges::width(gr[qh]), IRanges::width(gr[sh]))
+  d <- 1 - (IRanges::width(ov) / max_len)
+  
+  # Fill symmetric distance matrix
+  dist_mat[cbind(qh, sh)] <- d
+  dist_mat[cbind(sh, qh)] <- d
+  
+  # Perform agglomerative hierarchical clustering on the distance matrix
+  hc <- stats::hclust(stats::as.dist(dist_mat), method = linkage) 
+  
+  # Cut the dendrogram at height max_dist to define clusters
+  cluster <- stats::cutree(hc, h = max_dist) 
+  S4Vectors::mcols(gr)$cluster <- cluster
+  
+  #---------------------------------------------------------------
+  # 5. Filter clusters by minimum support
+  #---------------------------------------------------------------
+  meta <- S4Vectors::mcols(gr)
+  
+  valid_clusters <- meta |>
+    dplyr::as_tibble() |>
+    dplyr::group_by(cluster) |>
+    dplyr::summarise(
+      n_samples = dplyr::n_distinct(ID),
+      .groups = "drop"
+    ) |>
+    dplyr::filter(n_samples >= min_support) |>
+    dplyr::pull(cluster)
+  
+  if (length(valid_clusters) == 0) return(NULL)
+  
+  #---------------------------------------------------------------
+  # 6. Build recurrent regions
+  #---------------------------------------------------------------
+  regions_gr <- lapply(valid_clusters, function(cl) {
+    
+    events <- gr[cluster == cl]
+    
+    # Define region boundaries spanning all supporting events
+    region_start <- min(GenomicRanges::start(events))
+    region_end   <- max(GenomicRanges::end(events))
+    
+    region_gr_tmp <- GenomicRanges::GRanges(
+      seqnames = GenomicRanges::seqnames(events),
+      ranges   = IRanges::IRanges(region_start, region_end)
+    )
+    
+    GenomicRanges::GRanges(
+      seqnames = GenomicRanges::seqnames(events)[1],
+      ranges   = IRanges::IRanges(region_start, region_end),
+      n_samples = length(unique(S4Vectors::mcols(events)$ID)),
+      supporting_events = GenomicRanges::GRangesList(events)
+    )
+  })
+  
+  do.call(c, regions_gr)
 }

--- a/R/markRecurrentRegions.R
+++ b/R/markRecurrentRegions.R
@@ -1,23 +1,31 @@
 #' Annotate regions as recurrent or non-recurrent
 #'
 #' Given a results data.frame and a set of recurrent genomic regions,
-#' this function labels each row as "Yes" (recurrent) or "No".
+#' this function labels each row as "Yes" (recurrent) or "No" (non-recurrent)
+#' based on overlaps with a set of recurrent regions.
 #'
 #' @param df Data.frame with region coordinates and sample IDs.
 #' @param recurrent_regions GRanges object from identifyRecurrentRegions().
-#'
+#' @param min_overlap Numeric between 0 and 1, default = 0.7.
+#'    Minimum fraction of the input region that must overlap a recurrent region to be annotated as recurrent.
+#'   
+#' @details
+#' A region is marked as recurrent if the fraction of its length overlapping a recurrent region 
+#' is at least `min_overlap` (default 0.7).
+#' 
 #' @return The same data.frame with two added columns:
 #'   - Recurrent: "Yes" or "No"
 #'   - n_samples: Number of supporting samples (if recurrent)
+#'   
 #' @export
 #' @examples
 #' input <- data.frame(
-#'ID = c("S1", "S2", "S3", "S4"),
-#'chromosome = c("chr1", "chr1", "chr1", "chr2"),
-#'start = c(100, 120, 500, 100),
-#'end = c(150, 170, 550, 150),
-#'n_mendelian_error = c(10, 20, 5, 200)
-#')
+#'     ID = c("S1", "S2", "S3", "S4"),
+#'     chromosome = c("chr1", "chr1", "chr1", "chr2"),
+#'     start = c(100, 150, 500, 100),
+#'     end = c(150, 200, 550, 150),
+#'     n_mendelian_error = c(10, 20, 5, 200)
+#' )
 #'
 #'recurrent_gr <- GenomicRanges::GRanges(
 #'  seqnames = "chr1",
@@ -28,19 +36,13 @@
 #'  n_samples = 2
 #')
 #' markRecurrentRegions(input, recurrent_gr)
-markRecurrentRegions <- function(df, recurrent_regions) {
+#' 
+markRecurrentRegions <- function(df, recurrent_regions, min_overlap = 0.7) {
   
   # --- Detect coordinate columns automatically ---
-  if (all(c("start", "end") %in% colnames(df))) {
-    start_col <- "start"
-    end_col   <- "end"
-  } else if (all(c("min_start", "max_end") %in% colnames(df))) {
-    start_col <- "min_start"
-    end_col   <- "max_end"
-  } else {
-    stop("Input must contain either (start, end) or (min_start, max_end) columns.")
+  if (!all(c("start", "end") %in% names(df))) {
+    stop("Input must contain columns 'start' and 'end'.")
   }
-  
   
   # --- Initialize default output columns ---
   df$Recurrent <- "No"
@@ -54,21 +56,39 @@ markRecurrentRegions <- function(df, recurrent_regions) {
   # --- Convert input table to GRanges ---
   gr <- GenomicRanges::GRanges(
     seqnames = df$chromosome,
-    ranges = IRanges::IRanges(
-      start = as.numeric(df[[start_col]]),
-      end = as.numeric(df[[end_col]])
-    ),
-    ID = df$ID
+    ranges   = IRanges::IRanges(df$start, df$end),
+    ID       = df$ID
   )
   
-  
+  # --- Identify overlaps with recurrent regions ---
   overlaps <- GenomicRanges::findOverlaps(gr, recurrent_regions)
   
-  if (length(overlaps) > 0) {
-    df$Recurrent[S4Vectors::queryHits(overlaps)] <- "Yes"
-    df$n_samples[S4Vectors::queryHits(overlaps)] <-
-      recurrent_regions$n_samples[S4Vectors::subjectHits(overlaps)]
+  # --- If no overlaps are found, return input unchanged ---
+  if (length(overlaps) == 0) {
+    return(df)
   }
+  
+  qh <- S4Vectors::queryHits(overlaps)
+  sh <- S4Vectors::subjectHits(overlaps)
+  
+  # --- Compute overlap fraction for each overlapping event ---
+  
+  # Compute intersection between input regions and recurrent regions
+  ov <- GenomicRanges::pintersect(gr[qh], recurrent_regions[sh])
+  
+  # Fraction of the input event covered by the recurrent region
+  frac_covered <- IRanges::width(ov) / IRanges::width(gr[qh])
+  
+  # Retain only events exceeding the minimum overlap threshold
+  keep <- frac_covered >= min_overlap
+  
+  # --- Annotate recurrent events ---
+  if (any(keep)) {
+    df$Recurrent[qh[keep]] <- "Yes"
+    df$n_samples[qh[keep]] <-
+      recurrent_regions$n_samples[sh[keep]]
+  }
+  
   rownames(df) <- NULL
   return(df)
 }

--- a/man/collapseEvents.Rd
+++ b/man/collapseEvents.Rd
@@ -48,8 +48,8 @@ summarising the number of events, total Mendelian errors, the total span size,
 and a string listing all merged event coordinates.
 }
 \details{
-When ratio columns (\code{ratio_proband}, \code{ratio_mother}, \code{ratio_father}) are present,
-weighted mean ratios are computed across the collapsed events.
+When values are available in the ratio columns (\code{ratio_proband}, \code{ratio_mother}, \code{ratio_father})
+are present, weighted mean ratios are computed across the collapsed events.
 The weighted mean ratio is calculated as:
 
 \deqn{\frac{\sum_{i} r_i \times N_i}{\sum_{i} N_i}}

--- a/man/collapseEvents.Rd
+++ b/man/collapseEvents.Rd
@@ -48,8 +48,8 @@ summarising the number of events, total Mendelian errors, the total span size,
 and a string listing all merged event coordinates.
 }
 \details{
-When values are available in the ratio columns (\code{ratio_proband}, \code{ratio_mother}, \code{ratio_father})
-are present, weighted mean ratios are computed across the collapsed events.
+When values are available in the ratio columns (\code{ratio_proband}, \code{ratio_mother}, \code{ratio_father}),
+weighted mean ratios are computed across the collapsed events.
 The weighted mean ratio is calculated as:
 
 \deqn{\frac{\sum_{i} r_i \times N_i}{\sum_{i} N_i}}

--- a/man/identifyRecurrentRegions.Rd
+++ b/man/identifyRecurrentRegions.Rd
@@ -8,7 +8,9 @@ identifyRecurrentRegions(
   df,
   ID_col = "ID",
   error_threshold = 100,
-  min_support = 3
+  min_support = 3,
+  max_dist = 0.3,
+  linkage = "complete"
 )
 }
 \arguments{
@@ -18,7 +20,7 @@ identifyRecurrentRegions(
 \item chromosome: Chromosome name.
 \item start: Start coordinate of the region.
 \item end: End coordinate of the region.
-\item n_mendelian_error: Number of Mendelian errors in the region.
+\item n_mendelian_error or total_mendelian_error: Number of Mendelian errors in the region.
 }}
 
 \item{ID_col}{Character string indicating the column name containing
@@ -29,22 +31,79 @@ Maximum number of Mendelian errors allowed for a region to be considered.}
 
 \item{min_support}{Integer, default = 3.
 Minimum number of unique samples required to call a region recurrent.}
+
+\item{max_dist}{Numeric, default = 0.3.
+Maximum distance allowed to group events in the same cluster when cutting
+the hierarchical clustering dendrogram.}
+
+\item{linkage}{Character string specifying the linkage method for the
+agglomerative hierarchical clustering. Default \code{"complete"}, where the
+distance between two clusters is defined as the largest distance between
+all possible pairs of events belonging to the two clusters.}
 }
 \value{
 A GRanges object containing the recurrent regions that meet
-the minimum support threshold.
+the minimum support threshold. Metadata columns include:
+\itemize{
+\item \code{n_samples} – number of distinct samples supporting the region.
+\item \code{supporting_events} – a GRangesList with the individual events
+that compose the recurrent region, including per-event coverage metrics
+(pct_event_covered, pct_region_covered).
+}
+
+The \code{supporting_events} correspond exactly to the original events that
+were grouped into the cluster and define the boundaries of the resulting
+recurrent region.
+
+If no clusters meet the filtering criteria, the function returns \code{NULL}.
 }
 \description{
-This function finds recurrent genomic regions across samples based on overlapping intervals.
-Regions exceeding the Mendelian error threshold are excluded.
+This function identifies recurrent genomic regions supported by multiple
+samples based on overlapping genomic intervals. Intervals are first filtered
+by a Mendelian error threshold. Events are then clustered using an
+agglomerative hierarchical approach within each chromosome, with the distance
+between events defined based on their overlap. Clusters supported by a minimum
+number of distinct samples are retained and collapsed into recurrent regions
+summarizing all contributing events.
+}
+\details{
+The function operates chromosome-wise and proceeds in several steps. First,
+events are filtered based on a maximum Mendelian error threshold. Then, a
+pairwise distance matrix is computed for overlapping events, where the
+distance between two events e1 and e2 is defined as:
+
+\deqn{1 - (overlap\_width / max(width(e1), width(e2)))}
+
+Event pairs that do not overlap are not explicitly evaluated and are directly
+assigned a distance of 1. In addition, only the upper triangular part of the
+distance matrix is computed, exploiting its symmetry to avoid redundant
+calculations and reduce computational cost.
+
+Agglomerative hierarchical clustering is applied to this distance matrix. At
+each step, the most similar clusters are merged according to the specified
+linkage method (\code{linkage}), with the default \code{"complete"} linkage
+using the maximum distance between all possible pairs of events from the two
+clusters. The resulting dendrogram is cut at a height defined by
+\code{max_dist}, which represents the maximum distance allowed for events to
+be grouped in the same cluster. Smaller values enforce stricter overlap
+similarity.
+
+Only clusters supported by at least \code{min_support} distinct samples are
+retained. Each valid cluster is then collapsed into a single recurrent region
+whose coordinates span all contributing events, and the original events are
+stored as \code{supporting_events} with coverage metrics.
+
+These steps are performed internally by a helper function \code{identifyRecurrentRegionsByChr}.
+Results from all chromosomes are then combined into a single GRanges object returned by this function.
 }
 \examples{
 df <- data.frame(
-ID = c("S1", "S2", "S3", "S3"),
-chromosome = c("chr1", "chr1", "chr1", "chr1"),
-start = c(100, 120, 500, 510),
-end = c(150, 170, 550, 560),
-n_mendelian_error = c(10, 20, 5, 5)
+  ID = c("S1", "S2", "S3", "S4"),
+  chromosome = c("chr1", "chr1", "chr1", "chr1"),
+  start = c(100, 120, 500, 510),
+  end = c(150, 170, 550, 560),
+  n_mendelian_error = c(10, 20, 5, 5)
 )
 identifyRecurrentRegions(df, ID_col = "ID", error_threshold = 50, min_support = 2)
+
 }

--- a/man/identifyRecurrentRegions.Rd
+++ b/man/identifyRecurrentRegions.Rd
@@ -47,8 +47,7 @@ the minimum support threshold. Metadata columns include:
 \itemize{
 \item \code{n_samples} – number of distinct samples supporting the region.
 \item \code{supporting_events} – a GRangesList with the individual events
-that compose the recurrent region, including per-event coverage metrics
-(pct_event_covered, pct_region_covered).
+that compose the recurrent region.
 }
 
 The \code{supporting_events} correspond exactly to the original events that

--- a/man/markRecurrentRegions.Rd
+++ b/man/markRecurrentRegions.Rd
@@ -4,12 +4,15 @@
 \alias{markRecurrentRegions}
 \title{Annotate regions as recurrent or non-recurrent}
 \usage{
-markRecurrentRegions(df, recurrent_regions)
+markRecurrentRegions(df, recurrent_regions, min_overlap = 0.7)
 }
 \arguments{
 \item{df}{Data.frame with region coordinates and sample IDs.}
 
 \item{recurrent_regions}{GRanges object from identifyRecurrentRegions().}
+
+\item{min_overlap}{Numeric between 0 and 1, default = 0.7.
+Minimum fraction of the input region that must overlap a recurrent region to be annotated as recurrent.}
 }
 \value{
 The same data.frame with two added columns:
@@ -20,15 +23,20 @@ The same data.frame with two added columns:
 }
 \description{
 Given a results data.frame and a set of recurrent genomic regions,
-this function labels each row as "Yes" (recurrent) or "No".
+this function labels each row as "Yes" (recurrent) or "No" (non-recurrent)
+based on overlaps with a set of recurrent regions.
+}
+\details{
+A region is marked as recurrent if the fraction of its length overlapping a recurrent region
+is at least \code{min_overlap} (default 0.7).
 }
 \examples{
 input <- data.frame(
-ID = c("S1", "S2", "S3", "S4"),
-chromosome = c("chr1", "chr1", "chr1", "chr2"),
-start = c(100, 120, 500, 100),
-end = c(150, 170, 550, 150),
-n_mendelian_error = c(10, 20, 5, 200)
+    ID = c("S1", "S2", "S3", "S4"),
+    chromosome = c("chr1", "chr1", "chr1", "chr2"),
+    start = c(100, 150, 500, 100),
+    end = c(150, 200, 550, 150),
+    n_mendelian_error = c(10, 20, 5, 200)
 )
 
 recurrent_gr <- GenomicRanges::GRanges(
@@ -40,4 +48,5 @@ recurrent_gr <- GenomicRanges::GRanges(
  n_samples = 2
 )
 markRecurrentRegions(input, recurrent_gr)
+
 }

--- a/tests/testthat/test-collapseEvents.R
+++ b/tests/testthat/test-collapseEvents.R
@@ -1,38 +1,38 @@
 # Input test dataframe
 test_df <- data.frame(
-    ID = c("S1", "S1", "S1", "S1", "S1", "S1", "S2", "S2"),
-    chromosome = c("1", "1", "1", "1", "1","1","2", "2"),
-    start = c(50, 75, 100, 110, 150, 300, 500, 550),
-    end = c(70, 85, 120, 130, 180, 320, 520, 580),
-    n_snps = c(5, 3, 8, 10, 10, 6, 12, 7),
-    group = c("iso_mat", "iso_mat", "iso_mat", "iso_mat", "iso_mat", "het_pat", "iso_mat", "iso_mat"),
-    n_mendelian_error = c(1, 5, 5, 10, 10,  3, 50, 30),
-    ratio_father  = rep(NA_real_, 8),
-    ratio_mother  = rep(NA_real_, 8),
-    ratio_proband = rep(NA_real_, 8),
-    stringsAsFactors = FALSE
-  )
+  ID = c("S1", "S1", "S1", "S1", "S1", "S2", "S2"),
+  chromosome = c("1", "1", "1", "1", "1", "2", "2"),
+  start = c(50, 75, 100, 150, 300, 500, 550),
+  end = c(70, 85, 120, 180, 320, 520, 580),
+  n_snps = c(5, 3, 8, 10, 6, 12, 7),
+  group = c("iso_mat", "iso_mat", "iso_mat", "iso_mat", "het_pat", "iso_mat", "iso_mat"),
+  n_mendelian_error = c(1, 5, 5, 10, 3, 50, 30),
+  ratio_father  = rep(NA_real_, 7),
+  ratio_mother  = rep(NA_real_, 7),
+  ratio_proband = rep(NA_real_, 7),
+  stringsAsFactors = FALSE
+)
 
 
 # Expected result after collapsing
 expected_result <- data.frame(
-    ID = c("S1", "S1", "S2"),
-    chromosome = c("1", "1", "2"),
-    start = c(300,100, 500),
-    end = c(320, 180, 580),
-    group = c("het_pat","iso_mat", "iso_mat"),
-    n_events = c(1, 3, 2),
-    total_mendelian_error = c(3, 25, 80),
-    total_size = c(20, 80, 80),
-    total_snps = c(6, 28, 19),
-    prop_covered = c(1, 0.75, 0.625),
-    ratio_father  = rep(NA_real_, 3),
-    ratio_mother  = rep(NA_real_, 3),
-    ratio_proband = rep(NA_real_, 3),
-    collapsed_events = c( "1:300-320","1:100-120,1:110-130,1:150-180", "2:500-520,2:550-580"),
-    stringsAsFactors = FALSE
-  )
-  
+  ID = c("S1", "S1", "S2"),
+  chromosome = c("1", "1", "2"),
+  start = c(300,100, 500),
+  end = c(320, 180, 580),
+  group = c("het_pat","iso_mat", "iso_mat"),
+  n_events = c(1, 2, 2),
+  total_mendelian_error = c(3, 15, 80),
+  total_size = c(20, 80, 80),
+  total_snps = c(6, 18, 19),
+  prop_covered = c(1, 0.625, 0.625),
+  ratio_father  = rep(NA_real_, 3),
+  ratio_mother  = rep(NA_real_, 3),
+  ratio_proband = rep(NA_real_, 3),
+  collapsed_events = c( "1:300-320","1:100-120,1:150-180", "2:500-520,2:550-580"),
+  stringsAsFactors = FALSE
+)
+
 
 expected_cols <- c(
   "ID", "chromosome", "start", "end", "group", 
@@ -44,7 +44,7 @@ expected_cols <- c(
 test_that("Test if collapseEvents returns empty df with correct structure when all events are filtered out", {
   # Run function
   out <- collapseEvents(subset_df = test_df, min_ME = 2, min_size = 200)
-
+  
   # Must be empty
   expect_equal(nrow(out), 0)
   
@@ -107,11 +107,10 @@ test_that("Test if collapseEvents returns empty df with correct structure when a
   expect_equal(colnames(out), expected_cols)
   
 })   
-  
+
 test_that("Test if calculation collapseEvents works correctly (with ratios)", {
   # Run function
   out <- collapseEvents(subset_df = test_df, min_ME = 2, min_size = 19)
   # Test equality
   expect_equal(out, expected_result, tolerance = 1e-2)
 })
-

--- a/tests/testthat/test-collapseEvents.R
+++ b/tests/testthat/test-collapseEvents.R
@@ -1,15 +1,15 @@
 # Input test dataframe
 test_df <- data.frame(
-    ID = c("S1", "S1", "S1", "S1", "S1", "S2", "S2"),
-    chromosome = c("1", "1", "1", "1", "1", "2", "2"),
-    start = c(50, 75, 100, 150, 300, 500, 550),
-    end = c(70, 85, 120, 180, 320, 520, 580),
-    n_snps = c(5, 3, 8, 10, 6, 12, 7),
-    group = c("iso_mat", "iso_mat", "iso_mat", "iso_mat", "het_pat", "iso_mat", "iso_mat"),
-    n_mendelian_error = c(1, 5, 5, 10, 3, 50, 30),
-    ratio_father  = rep(NA_real_, 7),
-    ratio_mother  = rep(NA_real_, 7),
-    ratio_proband = rep(NA_real_, 7),
+    ID = c("S1", "S1", "S1", "S1", "S1", "S1", "S2", "S2"),
+    chromosome = c("1", "1", "1", "1", "1","1","2", "2"),
+    start = c(50, 75, 100, 110, 150, 300, 500, 550),
+    end = c(70, 85, 120, 130, 180, 320, 520, 580),
+    n_snps = c(5, 3, 8, 10, 10, 6, 12, 7),
+    group = c("iso_mat", "iso_mat", "iso_mat", "iso_mat", "iso_mat", "het_pat", "iso_mat", "iso_mat"),
+    n_mendelian_error = c(1, 5, 5, 10, 10,  3, 50, 30),
+    ratio_father  = rep(NA_real_, 8),
+    ratio_mother  = rep(NA_real_, 8),
+    ratio_proband = rep(NA_real_, 8),
     stringsAsFactors = FALSE
   )
 
@@ -21,15 +21,15 @@ expected_result <- data.frame(
     start = c(300,100, 500),
     end = c(320, 180, 580),
     group = c("het_pat","iso_mat", "iso_mat"),
-    n_events = c(1, 2, 2),
-    total_mendelian_error = c(3, 15, 80),
-    total_size = c(20, 50, 50),
-    total_snps = c(6, 18, 19),
-    prop_covered = c(1, 0.625, 0.625),
+    n_events = c(1, 3, 2),
+    total_mendelian_error = c(3, 25, 80),
+    total_size = c(20, 80, 80),
+    total_snps = c(6, 28, 19),
+    prop_covered = c(1, 0.75, 0.625),
     ratio_father  = rep(NA_real_, 3),
     ratio_mother  = rep(NA_real_, 3),
     ratio_proband = rep(NA_real_, 3),
-    collapsed_events = c( "1:300-320","1:100-120,1:150-180", "2:500-520,2:550-580"),
+    collapsed_events = c( "1:300-320","1:100-120,1:110-130,1:150-180", "2:500-520,2:550-580"),
     stringsAsFactors = FALSE
   )
   
@@ -86,7 +86,7 @@ expected_result <- data.frame(
   group = c("het_pat","iso_mat", "iso_mat"),
   n_events = c(1, 2, 2),
   total_mendelian_error = c(3, 15, 80),
-  total_size = c(20, 50, 50),
+  total_size = c(20, 80, 80),
   total_snps = c(6, 18, 19),
   prop_covered = c(1, 0.625, 0.625),
   ratio_father  = c(0.99, 0.97, 1.00),

--- a/tests/testthat/test-identifyRecurrentRegions.R
+++ b/tests/testthat/test-identifyRecurrentRegions.R
@@ -1,25 +1,32 @@
 df <- data.frame(
-  ID = c("S1", "S2", "S3", "S3"),
-  chromosome = c("chr1", "chr1", "chr1", "chr1"),
-  start = c(100, 120, 500, 510),
-  end = c(150, 170, 550, 560),
-  n_mendelian_error = c(10, 20, 5, 5)
+  ID = c("S1", "S2", "S3", "S4", "S5", "S6"),
+  chromosome = c("chr1", "chr1", "chr1", "chr1", "chr1", "chr1"),
+  start = c(100, 120, 130, 150, 400, 420),
+  end   = c(300, 320, 800, 350, 500, 520),
+  n_mendelian_error = c(10, 20, 5, 20, 5, 5)
 )
 
+events <- GenomicRanges::GRanges(
+  seqnames = "chr1",
+  ranges = IRanges::IRanges(start = c(100, 120, 150),
+                   end   = c(300, 320, 350)),
+  ID = c("S1", "S2", "S4"),
+  n_mendelian_error = c(10, 20, 20),
+  cluster = c(1,1,1)
+)
 
 expected <- GenomicRanges::GRanges(
   seqnames = "chr1",
   ranges = IRanges::IRanges(
     start = 100,
-    end = 170
+    end = 350
   ),
-  n_samples = 2
+  n_samples = 3,
+  supporting_events = GenomicRanges::GRangesList(events)
 )
-
-
 
 test_that("identifyRecurrentRegions", {
   # Run function
-  out <- identifyRecurrentRegions(df, ID_col = "ID", error_threshold = 50, min_support = 2)
+  out <- identifyRecurrentRegions(df)
   expect_equal(out, expected)
 })

--- a/tests/testthat/test-markRecurrentRegions.R
+++ b/tests/testthat/test-markRecurrentRegions.R
@@ -1,28 +1,26 @@
 input <- data.frame(
   ID = c("S1", "S2", "S3", "S4"),
-  chromosome = c("chr1", "chr1", "chr1", "chr2"),
-  start = c(100, 120, 500, 100),
-  end = c(150, 170, 550, 150),
-  n_mendelian_error = c(10, 20, 5, 200)
+  chromosome = c("chr1", "chr1", "chr1", "chr1"),
+  start = c(100, 150, 182, 400),
+  end   = c(300, 350, 382, 500)
 )
 
 recurrent_gr <- GenomicRanges::GRanges(
   seqnames = "chr1",
   ranges = IRanges::IRanges(
-    start = 100,
-    end = 170
+    start = 120, 
+    end = 320
   ),
-  n_samples = 2
+  n_samples = 3
 )
 
 expected <- data.frame(
   ID = c("S1", "S2", "S3", "S4"),
-  chromosome = c("chr1", "chr1", "chr1", "chr2"),
-  start = c(100, 120, 500, 100),
-  end = c(150, 170, 550, 150),
-  n_mendelian_error = c(10, 20, 5, 200),
+  chromosome = c("chr1", "chr1", "chr1", "chr1"),
+  start = c(100, 150, 182, 400),
+  end   = c(300, 350, 382, 500),
   Recurrent = c("Yes", "Yes", "No", "No"),
-  n_samples = c(2,2,1,1)
+  n_samples = c(3, 3, 1, 1)
 )
 
 test_that("Test if markRecurrentRegions works", {

--- a/vignettes/UPDhmm.Rmd
+++ b/vignettes/UPDhmm.Rmd
@@ -260,61 +260,46 @@ The resulting table contains one row per individual, chromosome, and UPD type, w
 
 The read-depth ratios are reported as supportive metrics to facilitate downstream interpretation. Values close to one indicate balanced coverage across trio members, whereas strong deviations may suggest copy-number gains or losses rather than true UPD events. Importantly, these ratios are not used as hard filtering criteria at this stage, but are provided to aid quality control and biological interpretation.
 
-# 4. Perform postprocessing analyses
+## 4. Perform postprocessing analyses
 
-In this final step, we perform postprocessing analyses to refine the detected UPD events and highlight potentially true or recurrent regions across samples.
-This helps to distinguish genuine biological UPDs from artifact-prone genomic regions (e.g., repetitive or complex loci that may systematically produce false positives).
+In this final step, we perform postprocessing analyses to refine the detected UPD events and highlight potentially true or recurrent regions across samples. This helps to distinguish genuine biological UPDs from artifact-prone genomic regions (e.g., repetitive or complex loci that may systematically produce false positives).
 
 To explore whether similar events recur across individuals, UPDhmm provides two complementary functions:
 
-- `identifyRecurrentRegions()` — identifies recurrent genomic regions shared across multiple samples by clustering overlapping genomic intervals. The function first filters events based on a Mendelian error threshold, then groups overlapping regions using an agglomerative hierarchical clustering approach applied chromosome-wise. Clusters supported by a minimum number of distinct individuals are collapsed into recurrent genomic regions.
+- `identifyRecurrentRegions()` — Identifies recurrent genomic regions shared across multiple samples by clustering overlapping genomic intervals.  
+  The function first filters events based on a Mendelian error threshold, then groups overlapping regions using an agglomerative hierarchical clustering approach applied chromosome-wise.  
+  Clusters supported by a minimum number of distinct individuals are collapsed into recurrent genomic regions.  
 
-It returns a GRanges object containing the recurrent regions, along with metadata describing sample support and the individual events contributing to each region. The function includes several arguments that control how recurrence is determined:
-  
-  *Arguments:*
-  - df —
-  The input data.frame containing the genomic regions to evaluate.
-  This table must include columns describing chromosome (chromosome), genomic coordinates (start, end), sample identifiers and a column with Mendelian error counts (n_mendelian_error or total_mendelian_error).
-    Filtering arguments:
-  - ID_col —
-  The name of the column containing sample identifiers.
-  It allows the function to determine how many unique individuals support each overlapping genomic region.
-  
-  - error_threshold (default = 100) —
-  Maximum number of Mendelian errors allowed for a region to be considered in the recurrence analysis.
-  Regions exceeding this threshold are excluded from recurrence counting. These regions, which often span broad genomic
-  segments, are not considered in the recurrence calculation since they could overlap with many smaller events and bias
-  the results. Instead, they are retained in the output as non-recurrent events, under the assumption that they may
-  represent genuine large-scale alterations rather than noise.
-  
-  - min_support (default = 3) —
-  Minimum number of distinct samples required for a cluster of overlapping events to be considered recurrent.
-  This parameter can be adjusted depending on the cohort size — smaller values detect more shared regions, while higher
-  thresholds focus on the most consistently recurrent events.
-  
-  - max_dist (default = 0.3) —
-  Maximum distance threshold used to cut the hierarchical clustering dendrogram.
-  Distance between two events is defined as:
-  \deqn{1 - (overlap\_width / max(event widths))}
-  Smaller values enforce stricter overlap similarity.
-  
-  - linkage (default = "complete") —
-  Linkage method used in agglomerative hierarchical clustering.
-  With "complete" linkage, the distance between two clusters is defined as the maximum distance between all pairs of events across clusters.
+  It returns a `GRanges` object containing the recurrent regions, along with metadata describing sample support and the individual events contributing to each region.
 
+  **Arguments:**
+  - `df` — The input data.frame containing the genomic regions to evaluate.  
+    This table must include columns describing chromosome (`chromosome`), genomic coordinates (`start`, `end`), sample identifiers, and a column with Mendelian error counts (`n_mendelian_error` or `total_mendelian_error`).
 
-- `markRecurrentRegions()` —
-  This function annotates each event in a results table (from calculateEvents() or collapseEvents()) as recurrent or
-  non-recurrent, depending on whether it sufficiently overlaps any region defined as recurrent.
+  **Filtering arguments:**
+  - `ID_col` — The name of the column containing sample identifiers.  
+    It allows the function to determine how many unique individuals support each overlapping genomic region.
+  - `error_threshold` (default = 100) — Maximum number of Mendelian errors allowed for a region to be considered in the recurrence analysis.  
+    Regions exceeding this threshold are excluded from recurrence counting. These regions, which often span broad genomic segments, are not considered in the recurrence calculation since they could overlap with many smaller events and bias the results. Instead, they are retained in the output as non-recurrent events, under the assumption that they may represent genuine large-scale alterations rather than noise.
+  - `min_support` (default = 3) — Minimum number of distinct samples required for a cluster of overlapping events to be considered recurrent.  
+    This parameter can be adjusted depending on the cohort size — smaller values detect more shared regions, while higher thresholds focus on the most consistently recurrent events.
+  - `max_dist` (default = 0.3) — Maximum distance threshold used to cut the hierarchical clustering dendrogram.  
+    Distance between two events is defined as:  
+    \deqn{1 - (overlap\_width / max(event widths))}  
+    Smaller values enforce stricter overlap similarity.
+  - `linkage` (default = "complete") — Linkage method used in agglomerative hierarchical clustering.  
+    With *complete* linkage, the distance between two clusters is defined as the maximum distance between all pairs of events across clusters.
+
+- `markRecurrentRegions()` — Annotates each event in a results table (from `calculateEvents()` or `collapseEvents()`) as recurrent or non-recurrent, depending on whether it sufficiently overlaps any region defined as recurrent.  
   Recurrence is determined by evaluating the fraction of the event length that overlaps a recurrent genomic region. Events are classified as recurrent only if this overlap fraction exceeds a user-defined threshold.
+
   The function returns the same data.frame provided as input, but with two additional columns:
-  - Recurrent: categorical variable indicating whether the event overlaps a recurrent region ("Yes" or "No").
-  - n_samples: the number of unique samples supporting that recurrent region (as determined in identifyRecurrentRegions()).
+  - `Recurrent` — Categorical variable indicating whether the event overlaps a recurrent region ("Yes" or "No").
+  - `n_samples` — Number of unique samples supporting the recurrent region (as determined in `identifyRecurrentRegions()`).
 
-These annotations facilitate the downstream filtering of events, allowing users to retain only non-recurrent regions, which are more likely to represent true UPD candidates rather than technical artifacts or common genomic polymorphisms.
-In summary, these two functions can thus be combined to systematically identify and flag recurrent genomic regions, facilitating the filtering of potential technical artifacts or recurrent UPDs.
+  These annotations facilitate downstream filtering of events, allowing users to retain only non-recurrent regions, which are more likely to represent true UPD candidates rather than technical artifacts or common genomic polymorphisms.
 
-
+In summary, these two functions can be combined to systematically identify and flag recurrent genomic regions, facilitating the filtering of potential technical artifacts or recurrent UPDs.
 
 ```{r}
 recurrentRegions <- identifyRecurrentRegions(

--- a/vignettes/UPDhmm.Rmd
+++ b/vignettes/UPDhmm.Rmd
@@ -295,7 +295,7 @@ It returns a GRanges object containing the recurrent regions, along with metadat
   - max_dist (default = 0.3) —
   Maximum distance threshold used to cut the hierarchical clustering dendrogram.
   Distance between two events is defined as:
-  \deqn{1 - (overlap\_width / max(event widths)}
+  \deqn{1 - (overlap\_width / max(event widths))}
   Smaller values enforce stricter overlap similarity.
   
   - linkage (default = "complete") —
@@ -305,7 +305,7 @@ It returns a GRanges object containing the recurrent regions, along with metadat
 
 - `markRecurrentRegions()` —
   This function annotates each event in a results table (from calculateEvents() or collapseEvents()) as recurrent or
-  non-recurrent,depending on whether it sufficiently overlaps any region defined as recurrent.
+  non-recurrent, depending on whether it sufficiently overlaps any region defined as recurrent.
   Recurrence is determined by evaluating the fraction of the event length that overlaps a recurrent genomic region. Events are classified as recurrent only if this overlap fraction exceeds a user-defined threshold.
   The function returns the same data.frame provided as input, but with two additional columns:
   - Recurrent: categorical variable indicating whether the event overlaps a recurrent region ("Yes" or "No").

--- a/vignettes/UPDhmm.Rmd
+++ b/vignettes/UPDhmm.Rmd
@@ -267,14 +267,14 @@ This helps to distinguish genuine biological UPDs from artifact-prone genomic re
 
 To explore whether similar events recur across individuals, UPDhmm provides two complementary functions:
 
-- `identifyRecurrentRegions()` — identifies overlapping regions across multiple samples and counts how many individuals
-share each region. It returns a GRanges object with the recurrent segments and the number of supporting samples. The function includes several arguments that control how recurrence is determined:
+- `identifyRecurrentRegions()` — identifies recurrent genomic regions shared across multiple samples by clustering overlapping genomic intervals. The function first filters events based on a Mendelian error threshold, then groups overlapping regions using an agglomerative hierarchical clustering approach applied chromosome-wise. Clusters supported by a minimum number of distinct individuals are collapsed into recurrent genomic regions.
+
+It returns a GRanges object containing the recurrent regions, along with metadata describing sample support and the individual events contributing to each region. The function includes several arguments that control how recurrence is determined:
   
   *Arguments:*
   - df —
   The input data.frame containing the genomic regions to evaluate.
-  This table must include columns describing chromosome (seqnames), genomic coordinates (start, end or min_start,
-  max_end), and a column with Mendelian error counts (n_mendelian_error or total_mendelian_error).
+  This table must include columns describing chromosome (chromosome), genomic coordinates (start, end), sample identifiers and a column with Mendelian error counts (n_mendelian_error or total_mendelian_error).
     Filtering arguments:
   - ID_col —
   The name of the column containing sample identifiers.
@@ -288,13 +288,25 @@ share each region. It returns a GRanges object with the recurrent segments and t
   represent genuine large-scale alterations rather than noise.
   
   - min_support (default = 3) —
-  Minimum number of unique samples that must overlap a region for it to be classified as recurrent.
+  Minimum number of distinct samples required for a cluster of overlapping events to be considered recurrent.
   This parameter can be adjusted depending on the cohort size — smaller values detect more shared regions, while higher
   thresholds focus on the most consistently recurrent events.
+  
+  - max_dist (default = 0.3) —
+  Maximum distance threshold used to cut the hierarchical clustering dendrogram.
+  Distance between two events is defined as:
+  \deqn{1 - (overlap\_width / max(event widths)}
+  Smaller values enforce stricter overlap similarity.
+  
+  - linkage (default = "complete") —
+  Linkage method used in agglomerative hierarchical clustering.
+  With "complete" linkage, the distance between two clusters is defined as the maximum distance between all pairs of events across clusters.
+
 
 - `markRecurrentRegions()` —
   This function annotates each event in a results table (from calculateEvents() or collapseEvents()) as recurrent or
-  non-recurrent,depending on whether it overlaps any region defined as recurrent.
+  non-recurrent,depending on whether it sufficiently overlaps any region defined as recurrent.
+  Recurrence is determined by evaluating the fraction of the event length that overlaps a recurrent genomic region. Events are classified as recurrent only if this overlap fraction exceeds a user-defined threshold.
   The function returns the same data.frame provided as input, but with two additional columns:
   - Recurrent: categorical variable indicating whether the event overlaps a recurrent region ("Yes" or "No").
   - n_samples: the number of unique samples supporting that recurrent region (as determined in identifyRecurrentRegions()).
@@ -309,7 +321,8 @@ recurrentRegions <- identifyRecurrentRegions(
   df = collapsed_all,
   ID_col = "ID",
   error_threshold = 100,
-  min_support = 2
+  min_support = 2,
+  max_dist = 0.97
 )
 
 head(recurrentRegions)


### PR DESCRIPTION
This PR introduces several improvements to how recurrent genomic regions are
defined, annotated, and summarized across the pipeline.

Key updates include:

**Refined recurrent annotation (markRecurrentRegions)**
Recurrent status is now determined using a minimum overlap fraction between
events and recurrent regions, preventing events with marginal overlap from
being annotated as recurrent.

**Corrected collapsed event size calculation (collapseEvents)**
The total size of collapsed events is now computed as the true genomic span
of the region rather than the sum of individual event sizes.

**More precise recurrent region definition (identifyRecurrentRegions)**
Replaced direct interval merging with an overlap-aware, chromosome-wise
agglomerative hierarchical clustering approach. Recurrent regions are now
defined based on overlap similarity between events, with configurable
clustering stringency.